### PR TITLE
fix: 챗봇 추천질문 및 참고문서 박스 CSS 조정

### DIFF
--- a/src/components/Chatbot.module.css
+++ b/src/components/Chatbot.module.css
@@ -242,7 +242,7 @@
   align-items: center;
   justify-content: center;
   border: 1px solid #9f132e;
-  width: 130px;
+  width: 140px;
   height: 20px;
   border-radius: 20px;
   font-size: 9px;
@@ -250,6 +250,8 @@
   transition: background-color 0.3s ease;
   padding-left: 23px;
   padding-right: 18px;
+  padding-top: 4px;
+  padding-bottom: 4px;
   text-align: center;
 }
 


### PR DESCRIPTION
현재 공식 asku.wiki 페이지에 챗봇 추천질문/참고문서 박스가 작아서 텍스트 짤리는 버그 발견하고 픽스해서
바로 main에 머지하려 합니다! 확인 부탁드립니다!

<기존 현재 asku.wiki>
![image](https://github.com/user-attachments/assets/90fdfc3d-e36d-474e-8f0b-787e904cb33c)

<변경한 UI>
![image](https://github.com/user-attachments/assets/9f5f9625-659e-43c9-8c69-fb98d6031a72)
